### PR TITLE
게시판 정렬 구현

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -3,16 +3,19 @@
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
     ('eyxnz', 'asdf1234', 'eyxnz', 'eyxnz@mail.com', 'I am eyxnz.', now(), 'eyxnz', now(), 'eyxnz')
 ;
+insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+    ('eyxnz2', 'asdf1234', 'eyxnz2', 'eyxnz2@mail.com', 'I am eyxnz2.', now(), 'eyxnz2', now(), 'eyxnz2')
+;
 
 -- 123 게시글
 insert into article (user_account_id, title, content, hashtag, created_by, modified_by, created_at, modified_at) values
-                                                                                                    (1, 'Quisque ut erat.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
+                                                                                                    (2, 'Quisque ut erat.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
 Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
 Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.', '#pink', 'Kamilah', 'Murial', '2021-05-30 23:53:46', '2021-03-10 08:48:50'),
-                                                                                                    (1, 'Morbi ut odio.', 'Phasellus in felis. Donec semper sapien a libero. Nam dui.
+                                                                                                    (2, 'Morbi ut odio.', 'Phasellus in felis. Donec semper sapien a libero. Nam dui.
 Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius.
 Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.', '#purple', 'Arv', 'Keelby', '2021-05-06 11:51:24', '2021-05-23 08:34:54'),
-                                                                                                    (1, 'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio.', 'Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '#purple', 'Adams', 'Thalia', '2021-08-13 08:32:22', '2021-04-02 02:58:19'),
+                                                                                                    (2, 'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio.', 'Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '#purple', 'Adams', 'Thalia', '2021-08-13 08:32:22', '2021-04-02 02:58:19'),
                                                                                                     (1, 'Fusce posuere felis sed lacus.', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.', '#mauv', 'Johny', 'Constantin', '2021-09-05 04:28:16', '2021-10-31 17:46:08'),
                                                                                                     (1, 'Aliquam erat volutpat.', 'Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '#green', 'Karlene', 'Marmaduke', '2022-01-25 16:10:23', '2021-11-08 08:47:03'),
                                                                                                     (1, 'Donec ut mauris eget massa tempor convallis.', 'Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.

--- a/src/main/resources/static/css/articles/table-header.css
+++ b/src/main/resources/static/css/articles/table-header.css
@@ -1,0 +1,5 @@
+/* 게시글 테이블 제목 */
+#article-table > thead a {
+    text-decoration: none;
+    color: black;
+}

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -6,6 +6,7 @@
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
   <link href="/css/search-bar.css" rel="stylesheet">
+  <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
 
 <body>
@@ -56,10 +57,10 @@
     <table class="table" id="article-table">
       <thead>
         <tr>
-          <th class="title col-6">제목</th>
-          <th class="hashtag col-2">해시태그</th>
-          <th class="user-id col">작성자</th>
-          <th class="created-at col">작성일</th>
+          <th class="title col-6"><a>제목</a></th>
+          <th class="hashtag col-2"><a>해시태그</a></th>
+          <th class="user-id col"><a>작성자</a></th>
+          <th class="created-at col"><a>작성일</a></th>
         </tr>
       </thead>
 

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -3,36 +3,57 @@
     <attr sel="#header" th:replace="header :: header" />
     <attr sel="#footer" th:replace="footer :: footer" />
 
-    <attr sel="#article-table">
-        <attr sel="tbody" th:remove="all-but-first">
-            <!-- th:remove="all-but-first" : 첫 번째 child 만 남기고 지우겠다 -->
-            <attr sel="tr[0]" th:each="article : ${articles}"> <!-- 치환 -->
-                <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                <attr sel="td.hashtag" th:text="${article.hashtag}" />
-                <attr sel="td.user-id" th:text="${article.nickname}" />
-                <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles(
+                    page=${articles.number},
+                    sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+                )}"/>
+                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
+                    page=${articles.number},
+                    sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+                 )}"/>
+                 <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles(
+                    page=${articles.number},
+                    sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : '')
+                 )}"/>
+                  <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles(
+                    page=${articles.number},
+                    sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+                 )}"/>
+            </attr>
+
+            <attr sel="tbody" th:remove="all-but-first">
+                <!-- th:remove="all-but-first" : 첫 번째 child 만 남기고 지우겠다 -->
+                <attr sel="tr[0]" th:each="article : ${articles}"> <!-- 치환 -->
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.hashtag" th:text="${article.hashtag}" />
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
             </attr>
         </attr>
-    </attr>
 
-    <!-- 네비게이션바 -->
-    <attr sel="#pagination">
-        <attr sel="li[0]/a"
-              th:text="'previous'"
-              th:href="@{/articles(page=${articles.number - 1})}"
-              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
-        />
-        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
-            <attr sel="a"
-                  th:text="${pageNumber + 1}"
-                  th:href="@{/articles(page=${pageNumber})}"
-                  th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+        <!-- 네비게이션바 -->
+        <attr sel="#pagination">
+            <attr sel="li[0]/a"
+                  th:text="'previous'"
+                  th:href="@{/articles(page=${articles.number - 1})}"
+                  th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+            />
+            <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                <attr sel="a"
+                      th:text="${pageNumber + 1}"
+                      th:href="@{/articles(page=${pageNumber})}"
+                      th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                />
+            </attr>
+            <attr sel="li[2]/a"
+                  th:text="'next'"
+                  th:href="@{/articles(page=${articles.number + 1})}"
+                  th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>
-        <attr sel="li[2]/a"
-              th:text="'next'"
-              th:href="@{/articles(page=${articles.number + 1})}"
-              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
-        />
     </attr>
 </thlogic>


### PR DESCRIPTION
게시판 페이지의 제목에 정렬 기능을 붙이는 작업을 완료했다.
각 제목을 한 번 클릭하면 오름차순으로 정렬되고, 다시 한 번 클릭하면 내림차순으로 정렬된다.
This closes #22 