### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/fastcampus/board/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/board/domain/UserAccount.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")


### PR DESCRIPTION
회원 계정의 `user_id` 에 UK 적용을 완료했다.

This closes #24 