### PR TITLE
DTO 들의 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/fastcampus/board/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcampus/board/dto/response/ArticleCommentResponse.java
@@ -11,7 +11,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable { // implements Serializable : 우리가 만든 클래스가 파일에 읽거나 쓸 수 있도록 하거나, 다른 서버로 보내거나 받을 수 있도록 하려면 추가
+) {
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);
     }

--- a/src/main/java/com/fastcampus/board/dto/response/ArticleResponse.java
+++ b/src/main/java/com/fastcampus/board/dto/response/ArticleResponse.java
@@ -13,7 +13,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);
     }

--- a/src/main/java/com/fastcampus/board/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fastcampus/board/dto/response/ArticleWithCommentsResponse.java
@@ -17,7 +17,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
     }


### PR DESCRIPTION
이 프로젝트는 직렬화로 Jackson 을 사용하므로 필요하지 않다. 
삭제하도록 한다.