### PR TITLE
equals() 가 올바르게 id 비교를 할 수 있도록 수정

### DIFF
--- a/src/main/java/com/fastcampus/board/domain/Article.java
+++ b/src/main/java/com/fastcampus/board/domain/Article.java
@@ -64,8 +64,8 @@ public class Article { // 게시글
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/board/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/board/domain/ArticleComment.java
@@ -55,7 +55,7 @@ public class ArticleComment { // 댓글
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/board/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/board/domain/UserAccount.java
@@ -51,8 +51,8 @@ public class UserAccount {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
엔티티 클래스의 `equals()` 을 통일한다.

This closes #38 